### PR TITLE
Increase the limit of the embed description (4096)

### DIFF
--- a/src/embed/index.js
+++ b/src/embed/index.js
@@ -40,7 +40,7 @@ class RichEmbed {
    */
   setDescription(description) {
     if (typeof description !== 'string') throw new TypeError(`Expected type 'string', received type '${typeof description}'`);
-    if (description.length > 2048) throw new RangeError('Embed descriptions cannot exceed 2048 characters');
+    if (description.length > 4096) throw new RangeError('Embed descriptions cannot exceed 4096 characters');
     this.description = description;
     return this;
   }


### PR DESCRIPTION
Based on [Discord API docs](https://discord.com/developers/docs/resources/channel#embed-limits)