### PR TITLE
feat(ERR_PACKAGE_PATH_NOT_EXPORTED): Fixes the following.

### DIFF
--- a/src/endpoints/index.js
+++ b/src/endpoints/index.js
@@ -5,6 +5,6 @@ const { warningMessage } = require('../../misc');
  */
 module.exports.init = (E) => {
   if (E.Endpoints !== undefined) return console.warn(`Eris.Endpoints is already defined! ${warningMessage('import')}`); // Because I'm an idiot and only supported functions
-  Object.defineProperty(E, 'Endpoints', { value: require('eris/lib/rest/Endpoints') });
+  Object.defineProperty(E, 'Endpoints', { value: require('../../../eris/lib/rest/Endpoints') });
   console.log('Loaded import Endpoints');
 };


### PR DESCRIPTION
Package subpath './lib/rest/Endpoints' is not defined by "exports" in /home/XX/XXX/XXXX/node_modules/pluris/node_modules/eris/package.json.

Searched location: /home/XX/XXX/XXXX/node_modules/pluris/node_modules/eris/package.json.
Required location: /home/XX/XXX/XXXX/node_modules/pluris/src/endpoints/index.js

The fix in this PR:

Changed index.js inside src/endpoints to search for eris in the main-node_modules, and not check for it outside.